### PR TITLE
Update xwidget-webkit-vimium.el

### DIFF
--- a/xwidget-webkit-vimium.el
+++ b/xwidget-webkit-vimium.el
@@ -388,7 +388,7 @@ LEAF is normally (NUM . XPATH)."
 
 (defvar xwidget-webkit-vimium-mode-map (make-sparse-keymap))
 
-(define-key xwidget-webkit-vimium-mode-map "f" 'xwwv-get-candidates)
+(define-key xwidget-webkit-vimium-mode-map "f" 'xwidget-webkit-vimium-get-candidates)
 
 ;;;###autoload
 (define-minor-mode xwidget-webkit-vimium-mode


### PR DESCRIPTION
The key binding was not working because a non-existing function was bound.